### PR TITLE
Maths typesetting and rename variable in documentation

### DIFF
--- a/models/ginzburg_neuron.h
+++ b/models/ginzburg_neuron.h
@@ -40,12 +40,12 @@ Description
 +++++++++++
 
 The ginzburg_neuron is an implementation of a binary neuron that
-is irregularly updated as Poisson time points. At each update
-point the total synaptic input h into the neuron is summed up,
-passed through a gain function g whose output is interpreted as
+is irregularly updated at Poisson time points. At each update
+point the total synaptic input :math:`h` into the neuron is summed up,
+passed through a gain function :math:`g` whose output is interpreted as
 the probability of the neuron to be in the active (1) state.
 
-The gain function g used here is :math:`g(h) = c_1*h + c_2 * 0.5*(1 +
+The gain function :math:`g` used here is :math:`g(h) = c_1*h + c_2 * 0.5*(1 +
 \tanh(c_3*(h-\theta)))` (output clipped to [0,1]). This allows to
 obtain affine-linear (:math:`c_1\neq0, c_2\neq0, c_3=0`) or sigmoidal (:math:`c_1=0,
 c_2=1, c_3\neq0`) shaped gain functions. The latter choice
@@ -57,17 +57,17 @@ The time constant :math:`\tau_m` is defined as the mean
 inter-update-interval that is drawn from an exponential
 distribution with this parameter. Using this neuron to reprodce
 simulations with asynchronous update [1]_, the time constant needs
-to be chosen as :math:`\tau_m = dt*N`, where dt is the simulation time
-step and N the number of neurons in the original simulation with
+to be chosen as :math:`\tau_m = dt*N`, where :math:`dt` is the simulation time
+step and :math:`N` the number of neurons in the original simulation with
 asynchronous update. This ensures that a neuron is updated on
 average every :math:`\tau_m` ms. Since in the original paper [1]_ neurons
 are coupled with zero delay, this implementation follows this
 definition. It uses the update scheme described in [3]_ to
 maintain causality: The incoming events in time step :math:`t_i` are
 taken into account at the beginning of the time step to calculate
-the gain function and to decide upon a transition.  In order to
-obtain delayed coupling with delay d, the user has to specify the
-delay d+h upon connection, where h is the simulation time step.
+the gain function and to decide upon a transition. In order to
+obtain delayed coupling with delay :math:`d`, the user has to specify the
+delay :math:`d+dt` upon connection, where :math:`dt` is the simulation time step.
 
 Remarks:
 


### PR DESCRIPTION
There was a naming conflict: the name "h" was used more than once with different meanings. This PR fixes that and adds some more mathematics rendering.